### PR TITLE
use other docker ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: postgres
     image: postgres:9.6
     ports:
-      - 5432:5432
+      - 55432:5432
     volumes:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     environment:


### PR DESCRIPTION
I would like to run docker with a different port, to avoid port problems with a local running postgresql database...